### PR TITLE
Fixed default graph so it has consistent axes

### DIFF
--- a/app.py
+++ b/app.py
@@ -415,4 +415,4 @@ def update_school_vax_rate(school_with_age):  # county):
 
 
 if __name__ == '__main__':
-    app.run(debug=True, host='0.0.0.0')
+    app.run(debug=False, host='0.0.0.0')

--- a/app_computation_functions.py
+++ b/app_computation_functions.py
@@ -1,0 +1,91 @@
+import measles_single_population as msp
+import pandas as pd
+import numpy as np
+import plotly.express as px
+
+from app_styles import SPAGHETTI_PLOT_AXIS_CONFIG
+
+
+def get_spaghetti_plot_infected_ma(df_plot: pd.DataFrame,
+                                   spaghetti_color_map: dict):
+    """
+    TODO: can be refactored to plot other dataframes too,
+    not just infected moving average.
+
+    Returns plotly.graph_objects.Figure
+    """
+
+    # Infuriating trying to get an empty lineplot NOT to display negative numbers
+    #   -- still does this even with repeated attempts at overriding by adjusting
+    #   "range"-related parameters :(
+    # To fix... don't show ticks if plot is empty
+
+    is_nonempty_df = not df_plot.empty
+
+    fig = px.line(
+        df_plot,
+        x='day',
+        y='number_infected_7_day_ma',
+        color='simulation_idx',
+        color_discrete_map=spaghetti_color_map,
+        labels={'simulation_idx': '', 'number_infected': 'Number of students infected', 'day': 'Day DD',
+                "number_infected_7_day_ma": "NN infected (7-day average)"},
+    )
+
+    fig.update_traces(hovertemplate="Day %{x}<br>%{y:.1f} Infected<extra></extra>")
+    fig.update_traces(line=dict(width=2))  # Reduce line thickness
+
+    fig.update_layout(showlegend=False,
+                      plot_bgcolor='white',
+                      margin=dict(l=0, r=0, t=0, b=0),
+                      xaxis=dict(
+                          title="Day",
+                          **SPAGHETTI_PLOT_AXIS_CONFIG,
+                          linecolor="grey",
+                          showticklabels=is_nonempty_df),
+                      yaxis=dict(
+                          title="Number of infected students",
+                          **SPAGHETTI_PLOT_AXIS_CONFIG,
+                          linecolor="black",
+                          showticklabels=is_nonempty_df
+                      ))
+
+    return fig
+
+
+def create_data_spaghetti_plot_infected_ma(sim: msp.StochasticSimulations,
+                                           nb_curves_displayed: int,
+                                           curve_selection_seed: int):
+    df_spaghetti_infected_ma = sim.df_spaghetti_infected_ma
+    index_sim_closest_median = sim.index_sim_closest_median
+
+    light_grey = 'rgb(220, 220, 220)'
+
+    color_map = {
+        x: light_grey
+        for x in df_spaghetti_infected_ma['simulation_idx'].unique()
+    }
+    color_map[index_sim_closest_median] = 'rgb(0, 153, 204)'  # blue
+
+    possible_idx = [
+        x for x in df_spaghetti_infected_ma['simulation_idx'].unique()
+        if x != index_sim_closest_median
+    ]
+
+    sample_idx = np.random.Generator(
+        np.random.MT19937(curve_selection_seed)).choice(possible_idx,
+                                                        nb_curves_displayed,
+                                                        replace=False)
+
+    sim_plot_df = pd.concat([
+        df_spaghetti_infected_ma.loc[df_spaghetti_infected_ma['simulation_idx'].isin(sample_idx)],
+        df_spaghetti_infected_ma.loc[df_spaghetti_infected_ma['simulation_idx'] == index_sim_closest_median]
+    ])
+
+    return sim_plot_df, color_map
+
+
+# Lauren wanted the default plot to have the same axes as the generated plot
+#   from simulations
+EMPTY_SPAGHETTI_PLOT_INFECTED_MA = get_spaghetti_plot_infected_ma(
+    pd.DataFrame(columns=['day', 'number_infected_7_day_ma', 'simulation_idx']), {})

--- a/app_dynamic_graphics.py
+++ b/app_dynamic_graphics.py
@@ -5,7 +5,7 @@ from dash import Dash, html, dcc, callback, Output, Input, State
 import dash_bootstrap_components as dbc
 
 from app_styles import BASE_FONT_FAMILY_STR, SELECTOR_NOTE_STYLE, RESULTS_HEADER_STYLE
-
+from app_computation_functions import EMPTY_SPAGHETTI_PLOT_INFECTED_MA
 
 def results_header():
     return dbc.Row(
@@ -85,7 +85,7 @@ def spaghetti_plot_section():
                                                "margin-left": "1.8em",
                                                "font-family": BASE_FONT_FAMILY_STR,
                                                "font-size": "14pt", "font-weight": "400", "font-style": "italic"}),
-                                dcc.Graph(id="spaghetti_plot"),
+                                dcc.Graph(id="spaghetti_plot", figure=EMPTY_SPAGHETTI_PLOT_INFECTED_MA),
                             ]),
                             style={'border': 'none', 'padding': '0'},
                         ),

--- a/app_styles.py
+++ b/app_styles.py
@@ -32,3 +32,23 @@ SELECTOR_NOTE_STYLE = {"text-align": "center",
 
 RESULTS_HEADER_STYLE = {'color': '#black', 'fontWeight': '500',
                         'font-size': '20pt', "margin": "none"}
+
+SPAGHETTI_PLOT_AXIS_CONFIG = {
+    'showgrid': True,
+    'gridcolor': "rgb(242,242,242)",
+    'title_font': {
+        'size': 20,
+        'color': "black",
+        'family': "Sans-serif"
+    },
+    'tickfont': {
+        'size': 16,
+        'color': "black",
+        'family': "Sans-serif"
+    },
+    'zeroline': True,
+    'zerolinecolor': "white",
+    'linewidth': 2,
+    'mirror': True,
+    'range': [0, None]
+}

--- a/assets/gtag.js
+++ b/assets/gtag.js
@@ -1,4 +1,20 @@
+     
+/*This function will load script and call the callback once the script has loaded*/
+function loadScriptAsync(scriptSrc, callback) {
+    if (typeof callback !== 'function') {
+        throw new Error('Not a valid callback for async script load');
+    }
+    var script = document.createElement('script');
+    script.onload = callback;
+    script.src = scriptSrc;
+    document.head.appendChild(script);
+}
+
+/* This is the part where you call the above defined function and "call back" your code which gets executed after the script has loaded */
+loadScriptAsync('https://www.googletagmanager.com/gtag/js?id=G-QS2CT3051Y', function(){
      window.dataLayer = window.dataLayer || [];
      function gtag(){dataLayer.push(arguments);}
      gtag('js', new Date());
      gtag('config', 'G-QS2CT3051Y');
+})
+

--- a/measles_single_population.py
+++ b/measles_single_population.py
@@ -585,7 +585,7 @@ params = {
     'is_stochastic': True,  # False for deterministic,
     "RNG_starting_seed": 147125098488
 }
-n_sim = 100
+n_sim = 200
 
 # %% Main
 ##########
@@ -594,6 +594,6 @@ if __name__ == "__main__":
     run_deterministic_model(params)
 
     # Stochastic runs
-    n_sim = 100
+    n_sim = 200
     stochastic_sim = StochasticSimulations(
         params, n_sim, print_summary_stats=True, show_plots=True)

--- a/measles_single_population.py
+++ b/measles_single_population.py
@@ -545,26 +545,6 @@ def run_deterministic_model(params):
     model_deterministic.plot_results()
 
 
-SPAGHETTI_PLOT_AXIS_CONFIG = {
-    'showgrid': True,
-    'gridcolor': "rgb(242,242,242)",
-    'title_font': {
-        'size': 20,
-        'color': "black",
-        'family': "Sans-serif"
-    },
-    'tickfont': {
-        'size': 16,
-        'color': "black",
-        'family': "Sans-serif"
-    },
-    'zeroline': True,
-    'zerolinecolor': "white",
-    'linewidth': 2,
-    'mirror': True
-}
-
-
 def create_strs_20plus_new_and_outbreak(sim: StochasticSimulations,
                                         outbreak_size_uncertainty_displayed: OUTBREAK_SIZE_UNCERTAINTY_OPTIONS):
     """
@@ -601,74 +581,6 @@ def create_strs_20plus_new_and_outbreak(sim: StochasticSimulations,
         cases_expected_over_20_str = uncertainty_outbreak_size_str + " total cases"
 
     return prob_20plus_new_str, cases_expected_over_20_str
-
-
-def gimme_spaghetti_infected_ma(sim: StochasticSimulations,
-                                nb_curves_displayed: int,
-                                curve_selection_seed: int):
-    """
-    Guess who named this function? ;)
-    Hope whoever is reading this has a good day! :)
-
-    TODO: can be refactored to plot other dataframes too,
-    not just infected moving average.
-
-    Returns plotly.graph_objects.Figure
-    """
-
-    df_spaghetti_infected_ma = sim.df_spaghetti_infected_ma
-    index_sim_closest_median = sim.index_sim_closest_median
-
-    light_grey = 'rgb(220, 220, 220)'
-
-    color_map = {
-        x: light_grey
-        for x in df_spaghetti_infected_ma['simulation_idx'].unique()
-    }
-    color_map[index_sim_closest_median] = 'rgb(0, 153, 204)'  # blue
-
-    possible_idx = [
-        x for x in df_spaghetti_infected_ma['simulation_idx'].unique()
-        if x != index_sim_closest_median
-    ]
-
-    sample_idx = np.random.Generator(
-        np.random.MT19937(curve_selection_seed)).choice(possible_idx,
-                                                        nb_curves_displayed,
-                                                        replace=False)
-
-    df_plot = pd.concat([
-        df_spaghetti_infected_ma.loc[df_spaghetti_infected_ma['simulation_idx'].isin(sample_idx)],
-        df_spaghetti_infected_ma.loc[df_spaghetti_infected_ma['simulation_idx'] == index_sim_closest_median]
-    ])
-
-    fig = px.line(
-        df_plot,
-        x='day',
-        y='number_infected_7_day_ma',
-        color='simulation_idx',
-        color_discrete_map=color_map,
-        labels={'simulation_idx': '', 'number_infected': 'Number of students infected', 'day': 'Day DD',
-                "number_infected_7_day_ma": "NN infected (7-day average)"},
-    )
-
-    fig.update_traces(hovertemplate="Day %{x}<br>%{y:.1f} Infected<extra></extra>")
-    fig.update_traces(line=dict(width=2))  # Reduce line thickness
-
-    fig.update_layout(showlegend=False,
-                      plot_bgcolor='white',
-                      margin=dict(l=0, r=0, t=0, b=0),
-                      xaxis=dict(
-                          title="Day",
-                          **SPAGHETTI_PLOT_AXIS_CONFIG,
-                          linecolor="grey"),
-                      yaxis=dict(
-                          title="Number of infected students",
-                          **SPAGHETTI_PLOT_AXIS_CONFIG,
-                          linecolor="black"
-                      ))
-
-    return fig
 
 
 # Set parameters


### PR DESCRIPTION
As per Lauren's request -- the default graph (blank graph upon loading and upon error message) should look similar to the graph generated after running simulations. Specifically retain the title + axes labels, and make sure there are no negative numbers on the axes!